### PR TITLE
Test max holds limit for regular patron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 .php_cs.cache
 .phpunit.result.cache
+/.idea/

--- a/features/lending/patron/place_on_hold.feature
+++ b/features/lending/patron/place_on_hold.feature
@@ -1,6 +1,10 @@
 Feature: Place book on hold
   In order to read a book Patrons should be able to place book on hold
 
+  Scenario: A regular patron cannot place on hold more than 5 books
+    When a regular patron with 5 holds place on hold circulating book on 7 days
+    Then place on hold should fail with reason "Regular patron cannot hold more books"
+
   Scenario: A regular patron cannot place on hold restricted book
     When a regular patron place on hold restricted book on 7 days
     Then place on hold should fail with reason "Regular patrons cannot hold restricted books"

--- a/tests/Context/DomainContext.php
+++ b/tests/Context/DomainContext.php
@@ -9,6 +9,7 @@ use Akondas\Library\Lending\Patron\Domain\NumberOfDays;
 use Akondas\Library\Lending\Patron\Domain\PatronEvent\BookHoldFailed;
 use Akondas\Library\Lending\Patron\Domain\PatronEvent\BookPlacedOnHold;
 use Behat\Behat\Context\Context;
+use Behat\Behat\Tester\Exception\PendingException;
 use Munus\Control\Either;
 
 final class DomainContext implements Context
@@ -24,6 +25,14 @@ final class DomainContext implements Context
     public function aRegularPatronPlaceOnHoldRestrictedBookOnDays(int $days): void
     {
         $this->hold = regularPatron()->placeOnHold(restrictedBook(), HoldDuration::closeEnded(NumberOfDays::of($days)));
+    }
+
+    /**
+     * @When a regular patron with :holds holds place on hold circulating book on :days days
+     */
+    public function aRegularPatronWithHoldsPlaceOnHold(int $holds, int $days): void
+    {
+        $this->hold = regularPatronWithHolds($holds)->placeOnHold(circulatingBook(), HoldDuration::closeEnded(NumberOfDays::of($days)));
     }
 
     /**

--- a/tests/Context/DomainContext.php
+++ b/tests/Context/DomainContext.php
@@ -9,7 +9,6 @@ use Akondas\Library\Lending\Patron\Domain\NumberOfDays;
 use Akondas\Library\Lending\Patron\Domain\PatronEvent\BookHoldFailed;
 use Akondas\Library\Lending\Patron\Domain\PatronEvent\BookPlacedOnHold;
 use Behat\Behat\Context\Context;
-use Behat\Behat\Tester\Exception\PendingException;
 use Munus\Control\Either;
 
 final class DomainContext implements Context

--- a/tests/Fixture/PatronFixture.php
+++ b/tests/Fixture/PatronFixture.php
@@ -12,6 +12,7 @@ use Akondas\Library\Lending\Patron\Domain\PatronType;
 use Akondas\Library\Lending\Patron\Domain\PlacingOnHoldPolicy;
 use Akondas\Library\Lending\Patron\Domain\PlacingOnHoldPolicy\OnlyResearcherPatronsCanHoldRestrictedBooks;
 use Akondas\Library\Lending\Patron\Domain\PlacingOnHoldPolicy\OnlyResearcherPatronsCanPlaceOpenEndedHolds;
+use Akondas\Library\Lending\Patron\Domain\PlacingOnHoldPolicy\RegularPatronMaximumNumberOfHoldsPolicy;
 use Munus\Collection\GenericList;
 use Munus\Collection\Set;
 use Munus\Collection\Stream;
@@ -26,6 +27,19 @@ function regularPatron(): Patron
             new OnlyResearcherPatronsCanHoldRestrictedBooks()
         ),
         noHolds()
+    );
+}
+
+function regularPatronWithHolds(int $numberOfHolds): Patron
+{
+    return new Patron(
+        new PatronInformation(anyPatronId(), PatronType::regular()),
+        GenericList::of(
+            new OnlyResearcherPatronsCanPlaceOpenEndedHolds(),
+            new OnlyResearcherPatronsCanHoldRestrictedBooks(),
+            new RegularPatronMaximumNumberOfHoldsPolicy()
+        ),
+        booksOnHold($numberOfHolds)
     );
 }
 


### PR DESCRIPTION
I created one more behat test for holds limit requirement
I've got an error on psalm analyze. The problem is in 55 line of `PatronFixture.php` file and it's `InvalidArgument` error. I have no idea how to fix it. In other similar GenericLists of policies, there is no problem like this.
@akondas I think you may know how to fix it :)