### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/Unit/Catalogue/CatalogueTest.php
+++ b/tests/Unit/Catalogue/CatalogueTest.php
@@ -29,7 +29,7 @@ class CatalogueTest extends TestCase
 
     private Catalogue $catalogue;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
         $this->database = self::createMock(CatalogueDatabase::class);


### PR DESCRIPTION
# Changed log

- According to the [official PHPUnit doc](https://phpunit.readthedocs.io/en/8.5/fixtures.html#more-setup-than-teardown), it should be the `protected function setUp` method.